### PR TITLE
Ignore interrupted system call

### DIFF
--- a/lib/Broker.js
+++ b/lib/Broker.js
@@ -13,6 +13,8 @@ function Broker(endpoint, conf) {
     this.endpoint = endpoint;
 	this.conf = conf || {};
 
+    this.HEARTBEAT_INTERVAL =  conf.HEARTBEAT_INTERVAL || HEARTBEAT_INTERVAL;
+
     this.services = {};
     this.workers = {};
 	this.reqs = {};
@@ -42,18 +44,21 @@ Broker.prototype.start = function(cb) {
 	if (this.conf.debug) {
 		debug('B: broker started on %s', this.endpoint);
 	}
-    
-	this.hbTimer = setInterval(function() {
-		self.workerPurge();
 
-		Object.keys(self.workers).every(function(workerId) {
-			var worker = self.workerRequire(workerId);
-			self.socket.send([workerId, MDP.WORKER, MDP.W_HEARTBEAT]);
-			return true;
-		});
-    }, HEARTBEAT_INTERVAL);
-    
-    cb();
+  var boundWorkerHeartbeat = this.heartbeat.bind(this);
+
+  this.hbTimer = setInterval(function() {
+    self.workerPurge();
+    Object.keys(self.workers).every(boundWorkerHeartbeat);
+  }, this.HEARTBEAT_INTERVAL);
+
+  cb();
+};
+
+Broker.prototype.heartbeat = function workerHeartbeat(workerId) {
+  var worker = this.workerRequire(workerId);
+  this.socket.send([workerId, MDP.WORKER, MDP.W_HEARTBEAT]);
+  return true;
 };
 
 Broker.prototype.stop = function() {

--- a/lib/Broker.js
+++ b/lib/Broker.js
@@ -57,7 +57,14 @@ Broker.prototype.start = function(cb) {
 
 Broker.prototype.heartbeat = function workerHeartbeat(workerId) {
   var worker = this.workerRequire(workerId);
-  this.socket.send([workerId, MDP.WORKER, MDP.W_HEARTBEAT]);
+  try {
+    this.socket.send([workerId, MDP.WORKER, MDP.W_HEARTBEAT]);
+  } catch (e) {
+    // ignore interrupted system call exceptions
+    if (e.message.toLowerCase() !== 'interrupted system call') {
+      throw e;
+    }
+  }
   return true;
 };
 

--- a/test/test-interrupted-system-call.js
+++ b/test/test-interrupted-system-call.js
@@ -1,0 +1,83 @@
+var test = require('tape');
+var omdp = require('../');
+var MDP = require('../lib/mdp')
+
+
+test('catch interrupted system call', function(t) {
+
+  var location = 'inproc://#1';
+  var broker = new omdp.Broker(location, {
+    HEARTBEAT_INTERVAL : 1
+  });
+  var worker = new omdp.Worker(location, 'echo');
+  worker.start();
+
+  // hotwire the addition of this worker to make the test run
+  // immediately.
+  broker.workers[worker.name] = worker;
+
+  // wrap heartbeat in a try/catch to detect errors
+  var heartbeat = broker.heartbeat;
+  broker.heartbeat = function override(workerId) {
+    try {
+      heartbeat.call(broker, workerId);
+    } catch (e) {
+      t.fail();
+    }
+    broker.stop();
+    worker.stop();
+    t.end();
+  }
+
+  broker.start(function() {
+
+    var send = broker.socket.send;
+    broker.socket.send = function sender(arr) {
+
+      if (arr[2] === MDP.W_HEARTBEAT) {
+        throw new Error('Interrupted System Call');
+      } else {
+        send.call(broker.socket, arr);
+      }
+    }
+  });
+});
+
+test('allow other errors to flow through', function(t) {
+  var location = 'inproc://#1';
+  var broker = new omdp.Broker(location, {
+    HEARTBEAT_INTERVAL : 1
+  });
+  var worker = new omdp.Worker(location, 'echo');
+  worker.start();
+
+  // hotwire the addition of this worker to make the test run
+  // immediately.
+  broker.workers[worker.name] = worker;
+
+  // wrap heartbeat in a try/catch to detect errors
+  var heartbeat = broker.heartbeat;
+  broker.heartbeat = function override(workerId) {
+    try {
+      heartbeat.call(broker, workerId);
+    } catch (e) {
+      t.fail();
+    }
+    broker.stop();
+    worker.stop();
+    t.end();
+  }
+
+  broker.start(function() {
+
+    var send = broker.socket.send;
+    broker.socket.send = function sender(arr) {
+
+      if (arr[2] === MDP.W_HEARTBEAT) {
+        throw new Error('some other thing');
+      } else {
+        send.call(broker.socket, arr);
+      }
+    }
+  });
+});

--- a/test/test-interrupted-system-call.js
+++ b/test/test-interrupted-system-call.js
@@ -19,11 +19,14 @@ test('catch interrupted system call', function(t) {
   // wrap heartbeat in a try/catch to detect errors
   var heartbeat = broker.heartbeat;
   broker.heartbeat = function override(workerId) {
+    var caught = false;
     try {
       heartbeat.call(broker, workerId);
     } catch (e) {
-      t.fail();
+      caught = true;
     }
+
+    t.ok(!caught);
     broker.stop();
     worker.stop();
     t.end();
@@ -58,11 +61,13 @@ test('allow other errors to flow through', function(t) {
   // wrap heartbeat in a try/catch to detect errors
   var heartbeat = broker.heartbeat;
   broker.heartbeat = function override(workerId) {
+    var caught = false;
     try {
       heartbeat.call(broker, workerId);
     } catch (e) {
-      t.fail();
+      caught = true;
     }
+    t.ok(caught);
     broker.stop();
     worker.stop();
     t.end();


### PR DESCRIPTION
This patch-set effectively ignores the dreaded "Interrupted System Call" and provides tests to ensure the behavior is correct.

As a side effect `lib/Broker.js` had to change a bit to support configurable heartbeat (for speed of test runs) and splitting out the innards of `Object.keys(this.workers).every(...)` into a `heartbeat` method to be wrapped in the tests for exception detection.
